### PR TITLE
Remove Unicode null before passing the file content to json.Unmarshal.

### DIFF
--- a/jsonutil/util.go
+++ b/jsonutil/util.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"bytes"
 )
 
 type MarshalFunc func(interface{}) ([]byte, error)
@@ -28,7 +29,8 @@ func ReadFile(path string, out interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal(content, out)
+	filtered := bytes.Replace(content, []byte("\\u0000"), []byte{}, -1);
+ 	err = json.Unmarshal(filtered, out)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi Robert,
(Retrying after a clean up)

Thank you for sharing a nice 1pass project in golang. I've looked at a few 1password compatible implementations and I liked this one a lot.

I found an issue when I opened my 1password data and I've created a patch. It'd be great if it is merged.

The problem was that many of my 1password entires failed to be decrypted. It turned out that these entries contains \u0000 in the JSON strings.

My patch filters this string. I could eliminate errors for my 1password data files.

Thanks,
-Gaku