### PR TITLE
fix tests failing from pexpect

### DIFF
--- a/client_test.py
+++ b/client_test.py
@@ -26,7 +26,7 @@ test_log = open('client_test.log', 'w')
 class OnePassCmd:
     def __init__(self, test, vault, cmd):
         self.test = test
-        onepass_cmd = './1pass -low-security -vault %s %s' % (vault, cmd)
+        onepass_cmd = 'sh -c "./1pass -low-security -vault %s %s"' % (vault, cmd)
         print('Running %s' % onepass_cmd, file=test_log)
         self.child = pexpect.spawn(onepass_cmd)
 


### PR DESCRIPTION
I'm not really sure why this works, or why `pexpect` works this way in the first place, but since this isn't a critical part of the core code, maybe this hack is ok.